### PR TITLE
Promote new Display Settings

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -22,7 +22,9 @@ Rng="*res://scripts/rng.gd"
 [display]
 
 window/size/viewport_width=1280
-window/size/viewport_height=720
+window/size/viewport_height=800
+window/stretch/mode="viewport"
+window/stretch/aspect="expand"
 
 [dotnet]
 


### PR DESCRIPTION
The settings include:
Steam Deck resolution: 1280x800
Expand with viewport

The main benefit is: Running always in the same resolution even if you change the window size. 

<img width="955" alt="image" src="https://github.com/user-attachments/assets/8e0d8ba5-e74e-494a-bfe9-c80fd37ad0e1" />
